### PR TITLE
Serial Read defined as ByteArrayLen

### DIFF
--- a/Main/Main.ino
+++ b/Main/Main.ino
@@ -119,7 +119,7 @@ byte* readPackage(){
       //makes sure there is a package finisher
       packageHasBeenFound = true;
       for (int i = 0; i < 3; i++){
-        if (Serial.read() != 255){
+        if (ByteArrayLen != 255){
           packageHasBeenFound = false;
         }
       }


### PR DESCRIPTION
ByteArrayLen was already defined before  as Serial.read(), so cant we use it again in the if statement?